### PR TITLE
Feature/np 2334 new pipeline structure

### DIFF
--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,9 +1,9 @@
-# variables: 
-# - template: variables/global-variables.yaml@ci_templates
-# - template: variables/go-variables.yaml@ci_templates
-# - template: variables/k8s-variables.yaml@ci_templates
-# - template: variables/nalej-variables.yaml@ci_templates
-# - template: variables/git-variables.yaml@ci_templates
+variables: 
+- template: variables/global-variables.yaml@ci_templates
+- template: variables/go-variables.yaml@ci_templates
+- template: variables/k8s-variables.yaml@ci_templates
+- template: variables/nalej-variables.yaml@ci_templates
+- template: variables/git-variables.yaml@ci_templates
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,17 +1,9 @@
-variables: 
-  - group: common-vars
-  - group: slack-webhooks
-  - group: docker-registries
-  - group: ci-service-principal
-  - group: ssh-credentials
-  - name: GOBIN
-    value: '$(GOPATH)/bin'
-  - name: GOROOT
-    value: '/usr/local/go1.13'
-  - name: GOPATH
-    value: '$(system.defaultWorkingDirectory)/gopath'
-  - name: modulePath
-    value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
+variables: 
+  - template: variables/global-variables.yaml@ci_templates
+  - template: variables/go-variables.yaml@ci_templates
+  - template: variables/k8s-variables.yaml@ci_templates
+  - template: variables/nalej-variables.yaml@ci_templates
+  - template: variables/git-variables.yaml@ci_templates
 
 resources:
   repositories:
@@ -19,7 +11,7 @@ resources:
       type: github
       name: nalej/ci-templates
       endpoint: nalej
-      ref: refs/tags/v1.0.3
+      ref: refs/tags/feature/NP-2334_New_Pipeline_Structure
 
 jobs:
 - job: MainWorkflow
@@ -28,9 +20,6 @@ jobs:
     vmImage: 'ubuntu-latest'
   
   steps:
-  - template: misc/variables.yaml@ci_templates
-
-  - template: misc/nalej-component.yaml@ci_templates
 
   - template: slack/build/start.yaml@ci_templates
     parameters:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,17 +1,17 @@
 variables: 
-  - group: common-vars
-  - group: slack-webhooks
-  - group: docker-registries
-  - group: ci-service-principal
-  - group: ssh-credentials
-  - name: GOBIN
-    value: '$(GOPATH)/bin'
-  - name: GOROOT
-    value: '/usr/local/go1.13'
-  - name: GOPATH
-    value: '$(system.defaultWorkingDirectory)/gopath'
-  - name: modulePath
-    value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
+- group: common-vars
+- group: slack-webhooks
+- group: docker-registries
+- group: ci-service-principal
+- group: ssh-credentials
+- name: GOBIN
+  value: '$(GOPATH)/bin'
+- name: GOROOT
+  value: '/usr/local/go1.13'
+- name: GOPATH
+  value: '$(system.defaultWorkingDirectory)/gopath'
+- name: modulePath
+  value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -35,6 +35,17 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
+    - script: |
+        language=$(cat .nalej-component.json | jq -r '.language')
+        echo '##vso[task.setvariable variable=language]'$language
+      name: SetLanguage
+
+  - job: GoWorkflow
+    dependsOn: MainWorkflow
+    condition: eq($[ dependencies.MainWorkflow.outputs['SetLanguage.language'] ], 'golang')
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
     - template: steps/go_main.yaml@ci_templates
 
 

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -46,7 +46,7 @@ stages:
     #     echo '##vso[task.prependpath]$(GOROOT)/bin'
     #   displayName: 'Set up the Go workspace'
 
-    - templates: go/workspace@ci_templates
+    - template: go/workspace@ci_templates
 
     - template: go/dep.yaml@ci_templates
       parameters:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,9 +1,17 @@
 variables: 
-#  - template: variables/global-variables.yaml@ci_templates
-  - template: variables/go-variables.yaml@ci_templates
-  - template: variables/k8s-variables.yaml@ci_templates
-  - template: variables/nalej-variables.yaml@ci_templates
-  - template: variables/git-variables.yaml@ci_templates
+  - group: common-vars
+  - group: slack-webhooks
+  - group: docker-registries
+  - group: ci-service-principal
+  - group: ssh-credentials
+  - name: GOBIN
+    value: '$(GOPATH)/bin'
+  - name: GOROOT
+    value: '/usr/local/go1.13'
+  - name: GOPATH
+    value: '$(system.defaultWorkingDirectory)/gopath'
+  - name: modulePath
+    value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
 
 resources:
   repositories:
@@ -29,104 +37,104 @@ stages:
         buildUrl: $(buildUrl)$(Build.BuildId)
         slackWebhook: $(slackBuilds)
 
-# - stage: 'Set Environment'
-#   jobs:
-#   - job: MainWorkflow
-#     pool:
-#       vmImage: 'ubuntu-latest'  
-#     steps:
-#     - script: |
-#         mkdir -p '$(GOBIN)'
-#         mkdir -p '$(GOPATH)/pkg'
-#         mkdir -p '$(modulePath)'
-#         shopt -s extglob
-#         shopt -s dotglob
-#         mv !(gopath) '$(modulePath)'
-#         echo '##vso[task.prependpath]$(GOBIN)'
-#         echo '##vso[task.prependpath]$(GOROOT)/bin'
-#       displayName: 'Set up the Go workspace'
+- stage: 'Set Environment'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - script: |
+        mkdir -p '$(GOBIN)'
+        mkdir -p '$(GOPATH)/pkg'
+        mkdir -p '$(modulePath)'
+        shopt -s extglob
+        shopt -s dotglob
+        mv !(gopath) '$(modulePath)'
+        echo '##vso[task.prependpath]$(GOBIN)'
+        echo '##vso[task.prependpath]$(GOROOT)/bin'
+      displayName: 'Set up the Go workspace'
 
-#     - template: go/dep.yaml@ci_templates
-#       parameters:
-#         sshHostName: $(hostName)
-#         sshPublicKey: $(sshPublicKey)
-#         modulePath: $(modulePath)
+    - template: go/dep.yaml@ci_templates
+      parameters:
+        sshHostName: $(hostName)
+        sshPublicKey: $(sshPublicKey)
+        modulePath: $(modulePath)
 
-# - stage: 'Testing'
-#   jobs:
-#   - job: MainWorkflow
-#     pool:
-#       vmImage: 'ubuntu-latest'  
-#     steps:
-#     - template: go/test.yaml@ci_templates
-#       parameters:
-#         modulePath: $(modulePath)
+- stage: 'Testing'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: go/test.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
 
-# - stage: 'Code Quality'
-#   jobs:
-#   - job: MainWorkflow
-#     pool:
-#       vmImage: 'ubuntu-latest'  
-#     steps:
-#     - template: go/gofmt.yaml@ci_templates
-#       parameters:
-#         modulePath: $(modulePath)
+- stage: 'Code Quality'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: go/gofmt.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
 
-# - stage: 'Build Binary'
-#   jobs:
-#   - job: MainWorkflow
-#     pool:
-#       vmImage: 'ubuntu-latest'  
-#     steps:
-#     - template: go/build.yaml@ci_templates
-#       parameters:
-#         modulePath: $(modulePath)
-#         appList: $(appList)
-#         version: $(version)
+- stage: 'Build Binary'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: go/build.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+        appList: $(appList)
+        version: $(version)
   
-# - stage: 'Build Image'
-#   jobs:
-#   - job: MainWorkflow
-#     pool:
-#       vmImage: 'ubuntu-latest'  
-#     steps:
-#     - template: docker/login.yaml@ci_templates
+- stage: 'Build Image'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: docker/login.yaml@ci_templates
       
-#     - template: docker/build.yaml@ci_templates
-#       parameters:
-#         modulePath: $(modulePath)
-#         imageList: $(imageList)
-#         version: edge
+    - template: docker/build.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+        imageList: $(imageList)
+        version: edge
     
-#     - template: docker/push.yaml@ci_templates
-#       parameters:
-#         modulePath: $(modulePath)
-#         imageList: $(imageList)
-#         version: edge
+    - template: docker/push.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+        imageList: $(imageList)
+        version: edge
       
-#     - template: docker/logout.yaml@ci_templates
+    - template: docker/logout.yaml@ci_templates
 
 
-# - stage: 'Finish Slack'
-#   jobs:
-#   - job: MainWorkflow
-#     pool:
-#       vmImage: 'ubuntu-latest'  
-#     steps: 
-#     - template: slack/build/finish.yaml@ci_templates
-#       parameters:
-#         author: $(authorName)
-#         repository: $(Build.Repository.Name)
-#         branch: $(Build.SourceBranch)
-#         commit: $(Build.SourceVersionMessage)
-#         buildUrl: $(buildUrl)$(Build.BuildId)
-#         slackWebhook: $(slackBuilds)
+- stage: 'Finish Slack'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps: 
+    - template: slack/build/finish.yaml@ci_templates
+      parameters:
+        author: $(authorName)
+        repository: $(Build.Repository.Name)
+        branch: $(Build.SourceBranch)
+        commit: $(Build.SourceVersionMessage)
+        buildUrl: $(buildUrl)$(Build.BuildId)
+        slackWebhook: $(slackBuilds)
     
-#     - template: slack/build/failed.yaml@ci_templates
-#       parameters:
-#         author: $(authorName)
-#         repository: $(Build.Repository.Name)
-#         branch: $(Build.SourceBranch)
-#         commit: $(Build.SourceVersionMessage)
-#         buildUrl: $(buildUrl)$(Build.BuildId)
-#         slackWebhook: $(slackCIFailed)
+    - template: slack/build/failed.yaml@ci_templates
+      parameters:
+        author: $(authorName)
+        repository: $(Build.Repository.Name)
+        branch: $(Build.SourceBranch)
+        commit: $(Build.SourceVersionMessage)
+        buildUrl: $(buildUrl)$(Build.BuildId)
+        slackWebhook: $(slackCIFailed)

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -37,7 +37,7 @@ stages:
         buildUrl: $(buildUrl)$(Build.BuildId)
         slackWebhook: $(slackBuilds)
 
-- stage: 'Set Environment'
+- stage: 'Set_Environment'
   jobs:
   - job: MainWorkflow
     pool:
@@ -70,7 +70,7 @@ stages:
       parameters:
         modulePath: $(modulePath)
 
-- stage: 'Code Quality'
+- stage: 'Code_Quality'
   jobs:
   - job: MainWorkflow
     pool:
@@ -80,7 +80,7 @@ stages:
       parameters:
         modulePath: $(modulePath)
 
-- stage: 'Build Binary'
+- stage: 'Build_Binary'
   jobs:
   - job: MainWorkflow
     pool:
@@ -92,7 +92,7 @@ stages:
         appList: $(appList)
         version: $(version)
   
-- stage: 'Build Image'
+- stage: 'Build_Image'
   jobs:
   - job: MainWorkflow
     pool:
@@ -115,7 +115,7 @@ stages:
     - template: docker/logout.yaml@ci_templates
 
 
-- stage: 'Finish Slack'
+- stage: 'Finish_Slack'
   jobs:
   - job: MainWorkflow
     pool:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -42,7 +42,7 @@ stages:
 
   - job: GoWorkflow
     dependsOn: MainWorkflow
-    condition: eq($[ dependencies.MainWorkflow.outputs['SetLanguage.language'] ], 'golang')
+    condition: eq('$[ dependencies.MainWorkflow.outputs['SetLanguage.language'] ]', 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -12,7 +12,7 @@ variables:
   value: '$(system.defaultWorkingDirectory)/gopath'
 - name: modulePath
   value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
-- template: variables/nalej-variables@ci_templates
+- template: variables/nalej-variables.yaml@ci_templates
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,7 +32,7 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    condition: eq($(language), 'golang')
+    condition: eq(variables['language'], 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -36,7 +36,7 @@ stages:
       vmImage: 'ubuntu-latest'  
     steps:
     - template: steps/go_main.yaml@ci_templates
-    # - template: go/workspace.yaml@ci_templates
+
 
     # - template: go/dep.yaml@ci_templates
     #   parameters:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -37,7 +37,7 @@ stages:
         buildUrl: $(buildUrl)$(Build.BuildId)
         slackWebhook: $(slackBuilds)
 
-- stage: 'Set_Environment'
+- stage: 'Go'
   jobs:
   - job: MainWorkflow
     pool:
@@ -59,27 +59,15 @@ stages:
         sshHostName: $(hostName)
         sshPublicKey: $(sshPublicKey)
         modulePath: $(modulePath)
-        
+
     - template: go/test.yaml@ci_templates
       parameters:
         modulePath: $(modulePath)
-
-- stage: 'Code_Quality'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
+ 
     - template: go/gofmt.yaml@ci_templates
       parameters:
         modulePath: $(modulePath)
 
-- stage: 'Build_Binary'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
     - template: go/build.yaml@ci_templates
       parameters:
         modulePath: $(modulePath)
@@ -92,6 +80,17 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
+    - script: |
+        mkdir -p '$(GOBIN)'
+        mkdir -p '$(GOPATH)/pkg'
+        mkdir -p '$(modulePath)'
+        shopt -s extglob
+        shopt -s dotglob
+        mv !(gopath) '$(modulePath)'
+        echo '##vso[task.prependpath]$(GOBIN)'
+        echo '##vso[task.prependpath]$(GOROOT)/bin'
+      displayName: 'Set up the Go workspace'
+      
     - template: docker/login.yaml@ci_templates
       
     - template: docker/build.yaml@ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -98,6 +98,7 @@ stages:
         commit: $(Build.SourceVersionMessage)
         buildUrl: $(buildUrl)$(Build.BuildId)
         slackWebhook: $(slackBuilds)
+        modulePath: $(modulePath)
     
     - template: slack/build/failed.yaml@ci_templates
       parameters:
@@ -107,3 +108,4 @@ stages:
         commit: $(Build.SourceVersionMessage)
         buildUrl: $(buildUrl)$(Build.BuildId)
         slackWebhook: $(slackCIFailed)
+        modulePath: $(modulePath)

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,14 +32,9 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    condition: eq(variables['language'], 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    - script: |
-        echo $(modulePath)
-        echo $(version)
-        echo $(language)
     - template: steps/go_main.yaml@ci_templates
     # - template: go/workspace.yaml@ci_templates
 

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -75,6 +75,7 @@ stages:
         version: $(version)
   
 - stage: 'Build_Image'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   jobs:
   - job: MainWorkflow
     pool:
@@ -90,7 +91,7 @@ stages:
         echo '##vso[task.prependpath]$(GOBIN)'
         echo '##vso[task.prependpath]$(GOROOT)/bin'
       displayName: 'Set up the Go workspace'
-      
+
     - template: docker/login.yaml@ci_templates
       
     - template: docker/build.yaml@ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,9 +1,9 @@
-variables: 
-- template: variables/global-variables.yaml@ci_templates
-- template: variables/go-variables.yaml@ci_templates
-- template: variables/k8s-variables.yaml@ci_templates
-- template: variables/nalej-variables.yaml@ci_templates
-- template: variables/git-variables.yaml@ci_templates
+# variables: 
+# - template: variables/global-variables.yaml@ci_templates
+# - template: variables/go-variables.yaml@ci_templates
+# - template: variables/k8s-variables.yaml@ci_templates
+# - template: variables/nalej-variables.yaml@ci_templates
+# - template: variables/git-variables.yaml@ci_templates
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,9 +1,9 @@
 variables: 
-  - template: variables/global-variables.yaml@ci_templates
-  - template: variables/go-variables.yaml@ci_templates
-  - template: variables/k8s-variables.yaml@ci_templates
-  - template: variables/nalej-variables.yaml@ci_templates
-  - template: variables/git-variables.yaml@ci_templates
+- template: variables/global-variables.yaml@ci_templates
+- template: variables/go-variables.yaml@ci_templates
+- template: variables/k8s-variables.yaml@ci_templates
+- template: variables/nalej-variables.yaml@ci_templates
+- template: variables/git-variables.yaml@ci_templates
 
 resources:
   repositories:
@@ -13,84 +13,120 @@ resources:
       endpoint: nalej
       ref: refs/tags/feature/NP-2334_New_Pipeline_Structure
 
-jobs:
-- job: MainWorkflow
+stages:
+- stage: 'Start Slack'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'    
+    steps:
+    - template: slack/build/start.yaml@ci_templates
+      parameters:
+        author: $(authorName)
+        repository: $(Build.Repository.Name)
+        branch: $(Build.SourceBranch)
+        commit: $(Build.SourceVersionMessage)
+        buildUrl: $(buildUrl)$(Build.BuildId)
+        slackWebhook: $(slackBuilds)
 
-  pool:
-    vmImage: 'ubuntu-latest'
+- stage: 'Set Environment'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - script: |
+        mkdir -p '$(GOBIN)'
+        mkdir -p '$(GOPATH)/pkg'
+        mkdir -p '$(modulePath)'
+        shopt -s extglob
+        shopt -s dotglob
+        mv !(gopath) '$(modulePath)'
+        echo '##vso[task.prependpath]$(GOBIN)'
+        echo '##vso[task.prependpath]$(GOROOT)/bin'
+      displayName: 'Set up the Go workspace'
+
+    - template: go/dep.yaml@ci_templates
+      parameters:
+        sshHostName: $(hostName)
+        sshPublicKey: $(sshPublicKey)
+        modulePath: $(modulePath)
+
+- stage: 'Testing'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: go/test.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+
+- stage: 'Code Quality'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: go/gofmt.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+
+- stage: 'Build Binary'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: go/build.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+        appList: $(appList)
+        version: $(version)
   
-  steps:
-
-  - template: slack/build/start.yaml@ci_templates
-    parameters:
-      author: $(authorName)
-      repository: $(Build.Repository.Name)
-      branch: $(Build.SourceBranch)
-      commit: $(Build.SourceVersionMessage)
-      buildUrl: $(buildUrl)$(Build.BuildId)
-      slackWebhook: $(slackBuilds)
-
-  - script: |
-      mkdir -p '$(GOBIN)'
-      mkdir -p '$(GOPATH)/pkg'
-      mkdir -p '$(modulePath)'
-      shopt -s extglob
-      shopt -s dotglob
-      mv !(gopath) '$(modulePath)'
-      echo '##vso[task.prependpath]$(GOBIN)'
-      echo '##vso[task.prependpath]$(GOROOT)/bin'
-    displayName: 'Set up the Go workspace'
-
-  - template: go/dep.yaml@ci_templates
-    parameters:
-      sshHostName: $(hostName)
-      sshPublicKey: $(sshPublicKey)
-      modulePath: $(modulePath)
-
-  - template: go/test.yaml@ci_templates
-    parameters:
-      modulePath: $(modulePath)
-
-  - template: go/gofmt.yaml@ci_templates
-    parameters:
-      modulePath: $(modulePath)
-
-  - template: go/build.yaml@ci_templates
-    parameters:
-      modulePath: $(modulePath)
-      appList: $(appList)
-      version: $(version)
-  
-  - template: docker/login.yaml@ci_templates
+- stage: 'Build Image'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps:
+    - template: docker/login.yaml@ci_templates
+      
+    - template: docker/build.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+        imageList: $(imageList)
+        version: edge
     
-  - template: docker/build.yaml@ci_templates
-    parameters:
-      modulePath: $(modulePath)
-      imageList: $(imageList)
-      version: edge
-  
-  - template: docker/push.yaml@ci_templates
-    parameters:
-      modulePath: $(modulePath)
-      imageList: $(imageList)
-      version: edge
+    - template: docker/push.yaml@ci_templates
+      parameters:
+        modulePath: $(modulePath)
+        imageList: $(imageList)
+        version: edge
+      
+    - template: docker/logout.yaml@ci_templates
+
+
+- stage: 'Finish Slack'
+  jobs:
+  - job: MainWorkflow
+    pool:
+      vmImage: 'ubuntu-latest'  
+    steps: 
+    - template: slack/build/finish.yaml@ci_templates
+      parameters:
+        author: $(authorName)
+        repository: $(Build.Repository.Name)
+        branch: $(Build.SourceBranch)
+        commit: $(Build.SourceVersionMessage)
+        buildUrl: $(buildUrl)$(Build.BuildId)
+        slackWebhook: $(slackBuilds)
     
-  - template: docker/logout.yaml@ci_templates
-    
-  - template: slack/build/finish.yaml@ci_templates
-    parameters:
-      author: $(authorName)
-      repository: $(Build.Repository.Name)
-      branch: $(Build.SourceBranch)
-      commit: $(Build.SourceVersionMessage)
-      buildUrl: $(buildUrl)$(Build.BuildId)
-      slackWebhook: $(slackBuilds)
-  
-  - template: slack/build/failed.yaml@ci_templates
-    parameters:
-      author: $(authorName)
-      repository: $(Build.Repository.Name)
-      branch: $(Build.SourceBranch)
-      commit: $(Build.SourceVersionMessage)
-      buildUrl: $(buildUrl)$(Build.BuildId)
-      slackWebhook: $(slackCIFailed)
+    - template: slack/build/failed.yaml@ci_templates
+      parameters:
+        author: $(authorName)
+        repository: $(Build.Repository.Name)
+        branch: $(Build.SourceBranch)
+        commit: $(Build.SourceVersionMessage)
+        buildUrl: $(buildUrl)$(Build.BuildId)
+        slackWebhook: $(slackCIFailed)

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -46,7 +46,7 @@ stages:
     #     echo '##vso[task.prependpath]$(GOROOT)/bin'
     #   displayName: 'Set up the Go workspace'
 
-    - template: go/workspace@ci_templates
+    - template: go/workspace.yaml@ci_templates
 
     - template: go/dep.yaml@ci_templates
       parameters:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -35,27 +35,28 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    - template: go/workspace.yaml@ci_templates
+    - template: steps/go_main.yaml@ci_templates
+    # - template: go/workspace.yaml@ci_templates
 
-    - template: go/dep.yaml@ci_templates
-      parameters:
-        sshHostName: $(hostName)
-        sshPublicKey: $(sshPublicKey)
-        modulePath: $(modulePath)
+    # - template: go/dep.yaml@ci_templates
+    #   parameters:
+    #     sshHostName: $(hostName)
+    #     sshPublicKey: $(sshPublicKey)
+    #     modulePath: $(modulePath)
 
-    - template: go/test.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
+    # - template: go/test.yaml@ci_templates
+    #   parameters:
+    #     modulePath: $(modulePath)
  
-    - template: go/gofmt.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
+    # - template: go/gofmt.yaml@ci_templates
+    #   parameters:
+    #     modulePath: $(modulePath)
 
-    - template: go/build.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
-        appList: $(appList)
-        version: $(version)
+    # - template: go/build.yaml@ci_templates
+    #   parameters:
+    #     modulePath: $(modulePath)
+    #     appList: $(appList)
+    #     version: $(version)
   
 - stage: 'Image_Build'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,25 +1,11 @@
-#variables: 
-# - template: variables/global-variables.yaml@ci_templates
-#- template: variables/go-variables.yaml@ci_templates
-# - template: variables/k8s-variables.yaml@ci_templates
-# - template: variables/nalej-variables.yaml@ci_templates
-# - template: variables/git-variables.yaml@ci_templates
+variables: 
+#- template: variables/global-variables.yaml@ci_templates
+- template: variables/go-variables.yaml@ci_templates
+- template: variables/k8s-variables.yaml@ci_templates
+- template: variables/nalej-variables.yaml@ci_templates
+- template: variables/git-variables.yaml@ci_templates
 
 
-variables: 
-  - group: common-vars
-  - group: slack-webhooks
-  - group: docker-registries
-  - group: ci-service-principal
-  - group: ssh-credentials
-  - name: GOBIN
-    value: '$(GOPATH)/bin'
-  - name: GOROOT
-    value: '/usr/local/go1.13'
-  - name: GOPATH
-    value: '$(system.defaultWorkingDirectory)/gopath'
-  - name: modulePath
-    value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,10 +32,14 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    condition: eq('${{ variables.language }}', 'golang')
+    #condition: eq('${{ variables.language }}', 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
+    - script: |
+        echo $(modulePath)
+        echo $(version)
+        echo $(language)
     - template: steps/go_main.yaml@ci_templates
     # - template: go/workspace.yaml@ci_templates
 

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,11 +1,9 @@
-variables: 
-#- template: variables/global-variables.yaml@ci_templates
-- template: variables/go-variables.yaml@ci_templates
-- template: variables/k8s-variables.yaml@ci_templates
-- template: variables/nalej-variables.yaml@ci_templates
-- template: variables/git-variables.yaml@ci_templates
-
-
+variables: 
+  - template: variables/global-variables.yaml@ci_templates
+  - template: variables/go-variables.yaml@ci_templates
+  - template: variables/k8s-variables.yaml@ci_templates
+  - template: variables/nalej-variables.yaml@ci_templates
+  - template: variables/git-variables.yaml@ci_templates
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -12,6 +12,7 @@ variables:
   value: '$(system.defaultWorkingDirectory)/gopath'
 - name: modulePath
   value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
+- template: variables/nalej-variables@ci_templates
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -12,8 +12,15 @@ variables:
   value: '$(system.defaultWorkingDirectory)/gopath'
 - name: modulePath
   value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
-- template: variables/nalej-variables.yaml@ci_templates
-
+- name: appList
+  value: $(cat .nalej-component.json | jq -r '.application_list| join(" ")')
+- name: imageList
+  value: $(cat .nalej-component.json | jq -r '.image_list| join(" ")')
+- name: version
+  value: $(cat .nalej-component.json | jq -r '.version')
+- name: language
+  value: $(cat .nalej-component.json | jq -r '.language')
+  
 resources:
   repositories:
     - repository: ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,9 +1,25 @@
-variables: 
+#variables: 
 # - template: variables/global-variables.yaml@ci_templates
-- template: variables/go-variables.yaml@ci_templates
+#- template: variables/go-variables.yaml@ci_templates
 # - template: variables/k8s-variables.yaml@ci_templates
 # - template: variables/nalej-variables.yaml@ci_templates
 # - template: variables/git-variables.yaml@ci_templates
+
+
+variables: 
+  - group: common-vars
+  - group: slack-webhooks
+  - group: docker-registries
+  - group: ci-service-principal
+  - group: ssh-credentials
+  - name: GOBIN
+    value: '$(GOPATH)/bin'
+  - name: GOROOT
+    value: '/usr/local/go1.13'
+  - name: GOPATH
+    value: '$(system.defaultWorkingDirectory)/gopath'
+  - name: modulePath
+    value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -110,6 +110,7 @@ stages:
 
 
 - stage: 'Finish_Slack'
+  condition: always()
   jobs:
   - job: MainWorkflow
     pool:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -14,7 +14,7 @@ resources:
       ref: 'refs/heads/feature/NP-2334_New_Pipeline_Structure'
 
 stages:
-- stage: 'Start Slack'
+- stage: 'Start_Slack'
   jobs:
   - job: MainWorkflow
     pool:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -29,23 +29,12 @@ stages:
         buildUrl: $(buildUrl)$(Build.BuildId)
         slackWebhook: $(slackBuilds)
 
-- stage: 'Go'
+- stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    # - script: |
-    #     mkdir -p '$(GOBIN)'
-    #     mkdir -p '$(GOPATH)/pkg'
-    #     mkdir -p '$(modulePath)'
-    #     shopt -s extglob
-    #     shopt -s dotglob
-    #     mv !(gopath) '$(modulePath)'
-    #     echo '##vso[task.prependpath]$(GOBIN)'
-    #     echo '##vso[task.prependpath]$(GOROOT)/bin'
-    #   displayName: 'Set up the Go workspace'
-
     - template: go/workspace.yaml@ci_templates
 
     - template: go/dep.yaml@ci_templates
@@ -68,23 +57,14 @@ stages:
         appList: $(appList)
         version: $(version)
   
-- stage: 'Build_Image'
+- stage: 'Image_Build'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   jobs:
   - job: MainWorkflow
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    - script: |
-        mkdir -p '$(GOBIN)'
-        mkdir -p '$(GOPATH)/pkg'
-        mkdir -p '$(modulePath)'
-        shopt -s extglob
-        shopt -s dotglob
-        mv !(gopath) '$(modulePath)'
-        echo '##vso[task.prependpath]$(GOBIN)'
-        echo '##vso[task.prependpath]$(GOROOT)/bin'
-      displayName: 'Set up the Go workspace'
+    - template: go/workspace.yaml@ci_templates
 
     - template: docker/login.yaml@ci_templates
       

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,7 +32,7 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    condition: eq('$(language)', 'golang')
+    condition: eq('${{ variables.language }}', 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -12,15 +12,8 @@ variables:
   value: '$(system.defaultWorkingDirectory)/gopath'
 - name: modulePath
   value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
-- name: appList
-  value: $(cat .nalej-component.json | jq -r '.application_list| join(" ")')
-- name: imageList
-  value: $(cat .nalej-component.json | jq -r '.image_list| join(" ")')
-- name: version
-  value: $(cat .nalej-component.json | jq -r '.version')
-- name: language
-  value: $(cat .nalej-component.json | jq -r '.language')
-  
+- template: variables/k8s-variables.yaml@ci_templates
+
 resources:
   repositories:
     - repository: ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -36,6 +36,7 @@ stages:
       vmImage: 'ubuntu-latest'  
     steps:
     - template: steps/go_main.yaml@ci_templates
+      condition: eq('$(language)', 'go')
     # - template: go/workspace.yaml@ci_templates
 
     # - template: go/dep.yaml@ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,21 +1,3 @@
-# variables: 
-# - group: common-vars
-# - group: slack-webhooks
-# - group: docker-registries
-# - group: ci-service-principal
-# - group: ssh-credentials
-# - name: GOBIN
-#   value: '$(GOPATH)/bin'
-# - name: GOROOT
-#   value: '/usr/local/go1.13'
-# - name: GOPATH
-#   value: '$(system.defaultWorkingDirectory)/gopath'
-# - name: modulePath
-#   value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
-# - template: variables/k8s-variables.yaml@ci_templates
-
-
-
 variables: 
   - template: variables/global-variables.yaml@ci_templates
   - template: variables/go-variables.yaml@ci_templates
@@ -53,16 +35,18 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    - script: |
-        mkdir -p '$(GOBIN)'
-        mkdir -p '$(GOPATH)/pkg'
-        mkdir -p '$(modulePath)'
-        shopt -s extglob
-        shopt -s dotglob
-        mv !(gopath) '$(modulePath)'
-        echo '##vso[task.prependpath]$(GOBIN)'
-        echo '##vso[task.prependpath]$(GOROOT)/bin'
-      displayName: 'Set up the Go workspace'
+    # - script: |
+    #     mkdir -p '$(GOBIN)'
+    #     mkdir -p '$(GOPATH)/pkg'
+    #     mkdir -p '$(modulePath)'
+    #     shopt -s extglob
+    #     shopt -s dotglob
+    #     mv !(gopath) '$(modulePath)'
+    #     echo '##vso[task.prependpath]$(GOBIN)'
+    #     echo '##vso[task.prependpath]$(GOROOT)/bin'
+    #   displayName: 'Set up the Go workspace'
+
+    - templates: go/workspace@ci_templates
 
     - template: go/dep.yaml@ci_templates
       parameters:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,6 +1,6 @@
 variables: 
-- template: variables/global-variables.yaml@ci_templates
-# - template: variables/go-variables.yaml@ci_templates
+# - template: variables/global-variables.yaml@ci_templates
+- template: variables/go-variables.yaml@ci_templates
 # - template: variables/k8s-variables.yaml@ci_templates
 # - template: variables/nalej-variables.yaml@ci_templates
 # - template: variables/git-variables.yaml@ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,12 +32,10 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    #condition: eq($(language), 'golang')
+    condition: eq('$(language)', 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    - script:
-        echo '$(language)'
     - template: steps/go_main.yaml@ci_templates
     # - template: go/workspace.yaml@ci_templates
 

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -29,104 +29,104 @@ stages:
         buildUrl: $(buildUrl)$(Build.BuildId)
         slackWebhook: $(slackBuilds)
 
-- stage: 'Set Environment'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
-    - script: |
-        mkdir -p '$(GOBIN)'
-        mkdir -p '$(GOPATH)/pkg'
-        mkdir -p '$(modulePath)'
-        shopt -s extglob
-        shopt -s dotglob
-        mv !(gopath) '$(modulePath)'
-        echo '##vso[task.prependpath]$(GOBIN)'
-        echo '##vso[task.prependpath]$(GOROOT)/bin'
-      displayName: 'Set up the Go workspace'
+# - stage: 'Set Environment'
+#   jobs:
+#   - job: MainWorkflow
+#     pool:
+#       vmImage: 'ubuntu-latest'  
+#     steps:
+#     - script: |
+#         mkdir -p '$(GOBIN)'
+#         mkdir -p '$(GOPATH)/pkg'
+#         mkdir -p '$(modulePath)'
+#         shopt -s extglob
+#         shopt -s dotglob
+#         mv !(gopath) '$(modulePath)'
+#         echo '##vso[task.prependpath]$(GOBIN)'
+#         echo '##vso[task.prependpath]$(GOROOT)/bin'
+#       displayName: 'Set up the Go workspace'
 
-    - template: go/dep.yaml@ci_templates
-      parameters:
-        sshHostName: $(hostName)
-        sshPublicKey: $(sshPublicKey)
-        modulePath: $(modulePath)
+#     - template: go/dep.yaml@ci_templates
+#       parameters:
+#         sshHostName: $(hostName)
+#         sshPublicKey: $(sshPublicKey)
+#         modulePath: $(modulePath)
 
-- stage: 'Testing'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
-    - template: go/test.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
+# - stage: 'Testing'
+#   jobs:
+#   - job: MainWorkflow
+#     pool:
+#       vmImage: 'ubuntu-latest'  
+#     steps:
+#     - template: go/test.yaml@ci_templates
+#       parameters:
+#         modulePath: $(modulePath)
 
-- stage: 'Code Quality'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
-    - template: go/gofmt.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
+# - stage: 'Code Quality'
+#   jobs:
+#   - job: MainWorkflow
+#     pool:
+#       vmImage: 'ubuntu-latest'  
+#     steps:
+#     - template: go/gofmt.yaml@ci_templates
+#       parameters:
+#         modulePath: $(modulePath)
 
-- stage: 'Build Binary'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
-    - template: go/build.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
-        appList: $(appList)
-        version: $(version)
+# - stage: 'Build Binary'
+#   jobs:
+#   - job: MainWorkflow
+#     pool:
+#       vmImage: 'ubuntu-latest'  
+#     steps:
+#     - template: go/build.yaml@ci_templates
+#       parameters:
+#         modulePath: $(modulePath)
+#         appList: $(appList)
+#         version: $(version)
   
-- stage: 'Build Image'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
-    - template: docker/login.yaml@ci_templates
+# - stage: 'Build Image'
+#   jobs:
+#   - job: MainWorkflow
+#     pool:
+#       vmImage: 'ubuntu-latest'  
+#     steps:
+#     - template: docker/login.yaml@ci_templates
       
-    - template: docker/build.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
-        imageList: $(imageList)
-        version: edge
+#     - template: docker/build.yaml@ci_templates
+#       parameters:
+#         modulePath: $(modulePath)
+#         imageList: $(imageList)
+#         version: edge
     
-    - template: docker/push.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
-        imageList: $(imageList)
-        version: edge
+#     - template: docker/push.yaml@ci_templates
+#       parameters:
+#         modulePath: $(modulePath)
+#         imageList: $(imageList)
+#         version: edge
       
-    - template: docker/logout.yaml@ci_templates
+#     - template: docker/logout.yaml@ci_templates
 
 
-- stage: 'Finish Slack'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps: 
-    - template: slack/build/finish.yaml@ci_templates
-      parameters:
-        author: $(authorName)
-        repository: $(Build.Repository.Name)
-        branch: $(Build.SourceBranch)
-        commit: $(Build.SourceVersionMessage)
-        buildUrl: $(buildUrl)$(Build.BuildId)
-        slackWebhook: $(slackBuilds)
+# - stage: 'Finish Slack'
+#   jobs:
+#   - job: MainWorkflow
+#     pool:
+#       vmImage: 'ubuntu-latest'  
+#     steps: 
+#     - template: slack/build/finish.yaml@ci_templates
+#       parameters:
+#         author: $(authorName)
+#         repository: $(Build.Repository.Name)
+#         branch: $(Build.SourceBranch)
+#         commit: $(Build.SourceVersionMessage)
+#         buildUrl: $(buildUrl)$(Build.BuildId)
+#         slackWebhook: $(slackBuilds)
     
-    - template: slack/build/failed.yaml@ci_templates
-      parameters:
-        author: $(authorName)
-        repository: $(Build.Repository.Name)
-        branch: $(Build.SourceBranch)
-        commit: $(Build.SourceVersionMessage)
-        buildUrl: $(buildUrl)$(Build.BuildId)
-        slackWebhook: $(slackCIFailed)
+#     - template: slack/build/failed.yaml@ci_templates
+#       parameters:
+#         author: $(authorName)
+#         repository: $(Build.Repository.Name)
+#         branch: $(Build.SourceBranch)
+#         commit: $(Build.SourceVersionMessage)
+#         buildUrl: $(buildUrl)$(Build.BuildId)
+#         slackWebhook: $(slackCIFailed)

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,10 +32,12 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    condition: eq($(language), 'golang')
+    #condition: eq($(language), 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
+    - script:
+        echo '$(language)'
     - template: steps/go_main.yaml@ci_templates
     # - template: go/workspace.yaml@ci_templates
 

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,7 +32,7 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    #condition: eq('${{ variables.language }}', 'golang')
+    condition: eq($(language), 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -59,13 +59,7 @@ stages:
         sshHostName: $(hostName)
         sshPublicKey: $(sshPublicKey)
         modulePath: $(modulePath)
-
-- stage: 'Testing'
-  jobs:
-  - job: MainWorkflow
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
+        
     - template: go/test.yaml@ci_templates
       parameters:
         modulePath: $(modulePath)

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,9 +1,9 @@
 variables: 
 - template: variables/global-variables.yaml@ci_templates
-- template: variables/go-variables.yaml@ci_templates
-- template: variables/k8s-variables.yaml@ci_templates
-- template: variables/nalej-variables.yaml@ci_templates
-- template: variables/git-variables.yaml@ci_templates
+# - template: variables/go-variables.yaml@ci_templates
+# - template: variables/k8s-variables.yaml@ci_templates
+# - template: variables/nalej-variables.yaml@ci_templates
+# - template: variables/git-variables.yaml@ci_templates
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -35,39 +35,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    - script: |
-        language=$(cat .nalej-component.json | jq -r '.language')
-        echo '##vso[task.setvariable variable=language]'$language
-      name: SetLanguage
-
-  - job: GoWorkflow
-    dependsOn: MainWorkflow
-    condition: eq('$[ dependencies.MainWorkflow.outputs['SetLanguage.language'] ]', 'golang')
-    pool:
-      vmImage: 'ubuntu-latest'  
-    steps:
     - template: steps/go_main.yaml@ci_templates
-
-
-    # - template: go/dep.yaml@ci_templates
-    #   parameters:
-    #     sshHostName: $(hostName)
-    #     sshPublicKey: $(sshPublicKey)
-    #     modulePath: $(modulePath)
-
-    # - template: go/test.yaml@ci_templates
-    #   parameters:
-    #     modulePath: $(modulePath)
- 
-    # - template: go/gofmt.yaml@ci_templates
-    #   parameters:
-    #     modulePath: $(modulePath)
-
-    # - template: go/build.yaml@ci_templates
-    #   parameters:
-    #     modulePath: $(modulePath)
-    #     appList: $(appList)
-    #     version: $(version)
   
 - stage: 'Image_Build'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
@@ -76,24 +44,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
-    - template: go/workspace.yaml@ci_templates
-
-    - template: docker/login.yaml@ci_templates
-      
-    - template: docker/build.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
-        imageList: $(imageList)
-        version: edge
-    
-    - template: docker/push.yaml@ci_templates
-      parameters:
-        modulePath: $(modulePath)
-        imageList: $(imageList)
-        version: edge
-      
-    - template: docker/logout.yaml@ci_templates
-
+    - template: steps/docker_main.yaml@ci_templates
 
 - stage: 'Finish_Slack'
   condition: always()

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -11,7 +11,7 @@ resources:
       type: github
       name: nalej/ci-templates
       endpoint: nalej
-      ref: refs/tags/feature/NP-2334_New_Pipeline_Structure
+      ref: 'refs/heads/feature/NP-2334_New_Pipeline_Structure'
 
 stages:
 - stage: 'Start Slack'

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,7 +32,7 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    condition: eq('$(language)', 'golang')
+    condition: eq($(language), 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,11 +32,11 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
+    condition: eq('$(language)', 'go')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
     - template: steps/go_main.yaml@ci_templates
-      condition: eq('$(language)', 'go')
     # - template: go/workspace.yaml@ci_templates
 
     # - template: go/dep.yaml@ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -32,7 +32,7 @@ stages:
 - stage: 'Binary_Build'
   jobs:
   - job: MainWorkflow
-    condition: eq('$(language)', 'go')
+    condition: eq('$(language)', 'golang')
     pool:
       vmImage: 'ubuntu-latest'  
     steps:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,5 +1,5 @@
 variables: 
-  - template: variables/global-variables.yaml@ci_templates
+#  - template: variables/global-variables.yaml@ci_templates
   - template: variables/go-variables.yaml@ci_templates
   - template: variables/k8s-variables.yaml@ci_templates
   - template: variables/nalej-variables.yaml@ci_templates

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -1,18 +1,27 @@
+# variables: 
+# - group: common-vars
+# - group: slack-webhooks
+# - group: docker-registries
+# - group: ci-service-principal
+# - group: ssh-credentials
+# - name: GOBIN
+#   value: '$(GOPATH)/bin'
+# - name: GOROOT
+#   value: '/usr/local/go1.13'
+# - name: GOPATH
+#   value: '$(system.defaultWorkingDirectory)/gopath'
+# - name: modulePath
+#   value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
+# - template: variables/k8s-variables.yaml@ci_templates
+
+
+
 variables: 
-- group: common-vars
-- group: slack-webhooks
-- group: docker-registries
-- group: ci-service-principal
-- group: ssh-credentials
-- name: GOBIN
-  value: '$(GOPATH)/bin'
-- name: GOROOT
-  value: '/usr/local/go1.13'
-- name: GOPATH
-  value: '$(system.defaultWorkingDirectory)/gopath'
-- name: modulePath
-  value: '$(GOPATH)/src/github.com/$(Build.Repository.Name)'
-- template: variables/k8s-variables.yaml@ci_templates
+  - template: variables/global-variables.yaml@ci_templates
+  - template: variables/go-variables.yaml@ci_templates
+  - template: variables/k8s-variables.yaml@ci_templates
+  - template: variables/nalej-variables.yaml@ci_templates
+  - template: variables/git-variables.yaml@ci_templates
 
 resources:
   repositories:

--- a/ci/azure-pipelines.main.yaml
+++ b/ci/azure-pipelines.main.yaml
@@ -30,15 +30,17 @@ stages:
         slackWebhook: $(slackBuilds)
 
 - stage: 'Binary_Build'
+  dependsOn: 'Start_Slack'
   jobs:
   - job: MainWorkflow
     pool:
       vmImage: 'ubuntu-latest'  
     steps:
     - template: steps/go_main.yaml@ci_templates
-  
+
 - stage: 'Image_Build'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  dependsOn: 'Binary_Build'
   jobs:
   - job: MainWorkflow
     pool:


### PR DESCRIPTION
#### What does this PR do?
The main pipeline has been refactored.
Main differences:
- all variables have been consolidates into (variables:) instead of being configured with setvariable. Main issue, they are resolved at runtime what causes issues if using them in condition: (for triggering different jobs per language)
- It has 4 stages (start_slack. binary_build, image_build, finish_slack). There is a limitation on the number of stages as a new VM is created per stage
- Go and Docker templates have been consolidated in a main template to simplify the process of changes propagation in the future (e.g. if adding a new template with new testing, we just change the main_template and not all the pipelines.
- Current limitation: angular pipeline needs to be different, I could not consolidate both languages in the same template

#### Where should the reviewer start?
azure-pipelines.main.yaml
#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2334](https://nalej.atlassian.net/browse/NP-2334)

#### Screenshots (if appropriate)

#### Questions
